### PR TITLE
Fix compiler errors in the zlib file reader

### DIFF
--- a/gme/Data_Reader.cpp
+++ b/gme/Data_Reader.cpp
@@ -290,13 +290,13 @@ blargg_err_t Gzip_File_Reader::open( const char* path )
 
 long Gzip_File_Reader::size() const { return size_; }
 
-long Gzip_File_Reader::read_avail( void* p, long s ) { return gzread( file_, p, s ); }
+long Gzip_File_Reader::read_avail( void* p, long s ) { return gzread( (gzFile) file_, p, s ); }
 
-long Gzip_File_Reader::tell() const { return gztell( file_ ); }
+long Gzip_File_Reader::tell() const { return gztell( (gzFile) file_ ); }
 
 blargg_err_t Gzip_File_Reader::seek( long n )
 {
-	if ( gzseek( file_, n, SEEK_SET ) >= 0 )
+	if ( gzseek( (gzFile) file_, n, SEEK_SET ) >= 0 )
 		return 0;
 	if ( n > size_ )
 		return eof_error;
@@ -307,7 +307,7 @@ void Gzip_File_Reader::close()
 {
 	if ( file_ )
 	{
-		gzclose( file_ );
+		gzclose( (gzFile) file_ );
 		file_ = 0;
 	}
 }


### PR DESCRIPTION
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp: In member function 'virtual long int Gzip_File_Reader::read_avail(void_, long int)':
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:293:71: error: invalid conversion from 'void_' to 'gzFile {aka gzFile_s_}' [-fpermissive]
 long Gzip_File_Reader::read_avail( void_ p, long s ) { return gzread( file_, p, s ); }
                                                                       ^
In file included from /tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:249:0:
/usr/include/zlib.h:1313:21: note:   initializing argument 1 of 'int gzread(gzFile, voidp, unsigned int)'
 ZEXTERN int ZEXPORT gzread OF((gzFile file, voidp buf, unsigned len));
                     ^
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp: In member function 'virtual long int Gzip_File_Reader::tell() const':
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:295:54: error: invalid conversion from 'void_' to 'gzFile {aka gzFile_s_}' [-fpermissive]
 long Gzip_File_Reader::tell() const { return gztell( file_ ); }
                                                      ^
In file included from /tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:249:0:
/usr/include/zlib.h:1727:28: note:   initializing argument 1 of 'off_t gztell(gzFile)'
    ZEXTERN z_off_t ZEXPORT gztell OF((gzFile));
                            ^
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp: In member function 'virtual const char\* Gzip_File_Reader::seek(long int)':
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:299:15: error: invalid conversion from 'void_' to 'gzFile {aka gzFile_s_}' [-fpermissive]
  if ( gzseek( file_, n, SEEK_SET ) >= 0 )
               ^
In file included from /tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:249:0:
/usr/include/zlib.h:1726:28: note:   initializing argument 1 of 'off_t gzseek(gzFile, off_t, int)'
    ZEXTERN z_off_t ZEXPORT gzseek OF((gzFile, z_off_t, int));
                            ^
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp: In member function 'void Gzip_File_Reader::close()':
/tmp/buildd/game-music-emu-0.6.0/gme/Data_Reader.cpp:310:12: error: invalid conversion from 'void_' to 'gzFile {aka gzFile_s_}' [-fpermissive]
   gzclose( file_ );
            ^
